### PR TITLE
記事一覧を返すAPIの実装とrequest specの実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,10 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.
   Max: 30
+
+RSpec/MultipleExpectations:
+  Max: 5
+
+# RSpec/EmptyExampleGroup:
+#   CustomIncludeMethods:
+#     include_tests

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "webpacker", "~> 4.0"
 gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
-gem "active_model_serializers"
+gem "active_model_serializers", "~> 0.10.0"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
@@ -63,7 +63,7 @@ group :development do
 
   gem "annotate"
 
-  gem "rails-erd"
+  # gem "rails-erd"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,6 @@ GEM
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
-    choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -164,11 +163,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (6.0.3.3)
@@ -221,8 +215,6 @@ GEM
       rubocop (>= 0.87.0)
     rubocop-rspec (1.43.2)
       rubocop (~> 0.87)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby-progressbar (1.10.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -275,7 +267,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers
+  active_model_serializers (~> 0.10.0)
   annotate
   bootsnap (>= 1.4.2)
   devise
@@ -290,7 +282,6 @@ DEPENDENCIES
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)
-  rails-erd
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < Api::V1::BaseApiController
+  def index
+    articles = Article.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,6 +3,6 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  validates :title, :user, presence: true
+  validates :title, presence: true
   validates :body, length: { minimum: 10 }
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  namespace :api do
+    namespace :v1 do
+      get "articles/index"
+    end
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do

--- a/db/migrate/20200915003233_add_user_id_to_articles.rb
+++ b/db/migrate/20200915003233_add_user_id_to_articles.rb
@@ -1,5 +1,5 @@
 class AddUserIdToArticles < ActiveRecord::Migration[6.0]
   def change
-    add_reference :articles, :user, null: false, foreign_key: true
+    add_reference :articles, :user, null: false, default: 1, foreign_key: true
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "これはテスト用のダミーテキストです。" }
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
+    user
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,31 +13,25 @@ RSpec.describe User, type: :model do
   context "名前のみ入力している場合" do
     let(:user) { build(:user, email: nil, password: nil) }
     it "エラーが発生する" do
-      aggregate_failures "最後まで通過"  do
-        expect(user).not_to be_valid
-        expect(user.errors.details[:password][0][:error]).to eq :blank
-        expect(user.errors.details[:email][0][:error]).to eq :blank
-      end
+      expect(user).not_to be_valid
+      expect(user.errors.details[:password][0][:error]).to eq :blank
+      expect(user.errors.details[:email][0][:error]).to eq :blank
     end
   end
 
   context "email がない場合" do
     let(:user) { build(:user, email: nil) }
     it "エラーが発生する" do
-      aggregate_failures "最後まで通過" do
-        expect(user).not_to be_valid
-        expect(user.errors.details[:email][0][:error]).to eq :blank
-      end
+      expect(user).not_to be_valid
+      expect(user.errors.details[:email][0][:error]).to eq :blank
     end
   end
 
   context "password がない場合" do
     let(:user) { build(:user, password: nil) }
     it "エラーが発生する" do
-      aggregate_failures "最後まで通過" do
-        expect(user).not_to be_valid
-        expect(user.errors.details[:password][0][:error]).to eq :blank
-      end
+      expect(user).not_to be_valid
+      expect(user.errors.details[:password][0][:error]).to eq :blank
     end
   end
 

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    # let!(:user) { create(:user) }
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+    it "記事一覧を取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      # ①記事一覧が取得できる
+      expect(res.length).to eq 3
+      # ②帰ってきた記事の一覧にbody が含まれていないこと
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      # ③記事が更新順に取得できること
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      # ④ステータスコードが200であること
+      expect(response).to have_http_status(:success)
+      # ⑤誰が書いた記事が取得できる
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- `api::v1::aricles_controller`を作成して、記事一覧を返すAPIの実装
- request specの実装